### PR TITLE
Resolve Arduino CI  MQTT Error

### DIFF
--- a/.github/workflows/arduino-build.yml
+++ b/.github/workflows/arduino-build.yml
@@ -20,6 +20,7 @@ jobs:
           arduino-cli core update-index --additional-urls "https://dl.espressif.com/dl/package_esp32_index.json"
           arduino-cli core install esp32:esp32 --additional-urls "https://dl.espressif.com/dl/package_esp32_index.json"
           arduino-cli lib install "Smartcar shield"
+          arduino-cli lib install "MQTT"
       - name: Build sketch
         run: |
           arduino-cli compile -b esp32:esp32:esp32doit-devkit-v1 arduino/smartcar/smartcar.ino


### PR DESCRIPTION
Resolved the error caused by missing MQTT import.